### PR TITLE
Fix sync-gpt placeholder

### DIFF
--- a/devops/sync/executable_sync-gpt.sh
+++ b/devops/sync/executable_sync-gpt.sh
@@ -1,1 +1,32 @@
-# (paste script contents from canvas)
+#!/bin/bash
+# sync-gpt.sh - Synchronize GPT state directory with GitHub using chezmoi
+
+set -e
+
+STATE_DIR="$HOME/.gptstate"
+CHEZMOI_DIR="$HOME/.local/share/chezmoi"
+
+# Ensure state directory exists
+if [[ ! -d "$STATE_DIR" ]]; then
+  echo "❌ GPT state directory not found: $STATE_DIR" >&2
+  exit 1
+fi
+
+# Stage changes in the GPT state directory
+chezmoi add "$STATE_DIR"
+chezmoi apply
+
+cd "$CHEZMOI_DIR"
+
+if git remote get-url origin >/dev/null 2>&1; then
+  if ! git diff --quiet; then
+    git add .
+    git commit -m '🔄 GPT state sync'
+    git push
+    echo "✅ GPT state synced to GitHub"
+  else
+    echo "ℹ️ No GPT state changes to sync"
+  fi
+else
+  echo "⚠️ No Git remote configured for chezmoi repo"
+fi


### PR DESCRIPTION
## Summary
- implement `executable_sync-gpt.sh` to sync GPT state via chezmoi
- make the script executable

## Testing
- `ruff check devops`
- `pytest`
- `npm test` *(fails: could not find package.json)*
- `shellcheck devops/sync/executable_sync-gpt.sh`


------
https://chatgpt.com/codex/tasks/task_e_683f645bdf888330baa39be2e802ef48