### PR TITLE
fix: clean merge markers in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,7 @@ services:
       - traefik_letsencrypt:/letsencrypt
     labels:
       - "traefik.enable=true"
-<<<<<<< HEAD
-      - "traefik.http.routers.traefik.rule=Host(${TRAEFIK_DOMAIN_PREFIX}.pegasuswingman.com)"
-=======
       - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN_PREFIX}.pegasuswingman.com`)"
->>>>>>> origin/main
       - "traefik.http.routers.traefik.entrypoints=web"
       - "traefik.http.routers.traefik.service=api@internal"
 


### PR DESCRIPTION
## Summary
- resolve git conflict markers in `docker-compose.yml`
- keep the intended rule using `${TRAEFIK_DOMAIN_PREFIX}`

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f694a58348330b38f21baa1858665