### PR TITLE
Implement sync-gpt shell script

### DIFF
--- a/devops/sync/executable_sync-gpt.sh
+++ b/devops/sync/executable_sync-gpt.sh
@@ -1,1 +1,40 @@
-# (paste script contents from canvas)
+#!/bin/bash
+# sync-gpt.sh - Track and push GPT state directory using chezmoi
+
+set -e
+
+STATE_DIR="$HOME/.gptstate"
+CHEZ_DIR="$HOME/.local/share/chezmoi"
+
+if [ ! -d "$STATE_DIR" ]; then
+  echo "❌ State directory $STATE_DIR not found" >&2
+  exit 1
+fi
+
+# Ensure chezmoi is installed
+if ! command -v chezmoi >/dev/null 2>&1; then
+  echo "❌ chezmoi command not found" >&2
+  exit 1
+fi
+
+cd "$STATE_DIR"
+
+# Track any changes in state directory
+chezmoi add .
+chezmoi apply
+
+# Commit and push if chezmoi repo has a remote
+if git -C "$CHEZ_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  cd "$CHEZ_DIR"
+  git add .
+  if ! git diff --cached --quiet; then
+    git commit -m "🔄 GPT state sync $(date +%F_%H:%M:%S)"
+    git push
+    echo "✅ GPT state pushed to GitHub"
+  else
+    echo "✅ No GPT state changes to push"
+  fi
+else
+  echo "⚠️ No Git repository configured for chezmoi state" >&2
+fi
+


### PR DESCRIPTION
## Summary
- implement `devops/sync/executable_sync-gpt.sh` to track and push GPT state via chezmoi

## Testing
- `shellcheck devops/sync/executable_sync-gpt.sh`
- `find devops/scripts -name '*.sh' -exec shellcheck {} +`
- `find devops/scripts -name '*.sh' -exec bash -n {} +`
- `bash devops/scripts/validate-all-scripts.sh`
- `ruff check python/`
- `pytest`
- `npm ci`
- `npx eslint .`
- `npm test`
- `docker build -t wingman/test .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406a40baf48330a294130124367ce4