### PR TITLE
Fix conflict markers in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,11 +24,7 @@ services:
       - traefik_letsencrypt:/letsencrypt
     labels:
       - "traefik.enable=true"
-<<<<<<< ours
       - "traefik.http.routers.traefik.rule=Host(${TRAEFIK_DOMAIN_PREFIX}.pegasuswingman.com)"
-=======
-      - "traefik.http.routers.traefik.rule=Host(`${TRAEFIK_DOMAIN_PREFIX}.pegasuswingman.com`)"
->>>>>>> theirs
       - "traefik.http.routers.traefik.entrypoints=web"
       - "traefik.http.routers.traefik.service=api@internal"
 


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in `docker-compose.yml`
- keep the Traefik router rule using `Host(${TRAEFIK_DOMAIN_PREFIX}.pegasuswingman.com)` syntax

## Testing
- `pytest -q` *(fails: SyntaxError in python/tests/test_shebangs.py)*

------
https://chatgpt.com/codex/tasks/task_e_6843413fed1483309ca79b305b4fd2d1