### PR TITLE
docs: correct history expansion comment

### DIFF
--- a/scripts/executable_deploy_edge_agent.sh
+++ b/scripts/executable_deploy_edge_agent.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-set +H  # Disable history expansion
+set +H  # Disable history expansion in bash
 
 SCRIPT_NAME=$(basename "$0")
 AGENT_NAME="portainer_edge_agent"


### PR DESCRIPTION
## Summary
- document that `set +H` disables history expansion in bash

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684351e3c8b0833081c4a93cb8c50e1b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified a comment in the deployment script for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->