### PR TITLE
test: verify docker-compose has no conflict markers

### DIFF
--- a/python/tests/test_placeholder.py
+++ b/python/tests/test_placeholder.py
@@ -3,7 +3,11 @@ import yaml
 
 
 def test_docker_compose_has_no_conflict_markers():
-    compose_path = Path(__file__).resolve().parents[2] / "docker-compose.yml"
-    content = compose_path.read_text()
-    assert "<<<<<<<" not in content and ">>>>>>>" not in content
+    """Ensure docker-compose.yml contains no merge conflict markers."""
+    compose_file = Path(__file__).resolve().parents[2] / "docker-compose.yml"
+    content = compose_file.read_text()
+
+    assert "<<<<<<<" not in content
+    assert ">>>>>>>" not in content
+
     yaml.safe_load(content)


### PR DESCRIPTION
## Summary
- ensure `docker-compose.yml` has no merge conflict markers

## Testing
- `pytest -q` *(fails: SyntaxError in test_shebangs.py)*

------
https://chatgpt.com/codex/tasks/task_e_684351e5351483309b67f9d5c08dfc18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved clarity and readability of an existing test by updating variable names, adding a descriptive docstring, and splitting combined assertions into separate checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->