### PR TITLE
Load landscape config from env

### DIFF
--- a/devops/scripts/executable_register-landscape-client.sh
+++ b/devops/scripts/executable_register-landscape-client.sh
@@ -3,10 +3,24 @@
 
 set -e
 
-# Configurable values
-title="pegasus"
-account="illthvh4"
-reg_key="0PjgUOsvyX4zvxZxdVFBnNrfKyG/tw1B6HB3pSfx"
+# Load environment variables from repo .env if present
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="$SCRIPT_DIR/../../.env"
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+fi
+
+# Required values
+title="${LANDSCAPE_TITLE}"
+account="${LANDSCAPE_ACCOUNT}"
+reg_key="${LANDSCAPE_REG_KEY}"
+
+if [[ -z "$title" || -z "$account" || -z "$reg_key" ]]; then
+  echo "Environment variables LANDSCAPE_TITLE, LANDSCAPE_ACCOUNT, and LANDSCAPE_REG_KEY must be set."
+  exit 1
+fi
 
 # Check root
 if [[ $EUID -ne 0 ]]; then

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,3 +8,13 @@ Welcome to **Wingman** – your DevOps automation hub.
 - [GitHub Repository](https://github.com/1tsjeremiah/wingman)
 - [CI/CD Status](https://github.com/1tsjeremiah/wingman/actions)
 - [Docs](./index.md)
+
+## Configuration
+
+The Landscape registration scripts expect the following environment variables to be set or provided in a `.env` file at the repository root:
+
+- `LANDSCAPE_TITLE` – the computer title to register
+- `LANDSCAPE_ACCOUNT` – your Landscape account name
+- `LANDSCAPE_REG_KEY` – the registration key issued by Landscape
+
+These values are loaded automatically when running the registration script.


### PR DESCRIPTION
## Summary
- load `.env` if present in `register-landscape-client.sh`
- pull Landscape credentials from env vars
- document `LANDSCAPE_*` environment variables in docs

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684329bec3d08330aca1c9eb783eaf1e