### PR TITLE
Add Codex verification script

### DIFF
--- a/.github/workflows/verify-codex.yml
+++ b/.github/workflows/verify-codex.yml
@@ -1,0 +1,15 @@
+name: Verify Codex Changes
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+      - name: Run verification script
+        run: scripts/verify_codex_changes.sh

--- a/scripts/verify_codex_changes.sh
+++ b/scripts/verify_codex_changes.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euo pipefail
+
+# Print the 10 most recently modified files in the repo
+echo "[+] 10 most recently modified files:"
+find . -path ./.git -prune -o -type f -printf '%T@ %p\n' 2>/dev/null | sort -nr | head -n 10 | cut -d' ' -f2-
+
+echo
+if [ -d .git ]; then
+  echo "[+] Git status:"
+  git status
+  echo
+  echo "[+] Git diff:"
+  git diff
+fi
+
+echo
+CODEx_SESSIONS_DIR="$HOME/.codex/sessions"
+if [ -d "$CODEx_SESSIONS_DIR" ]; then
+  latest_session=$(ls -dt "$CODEx_SESSIONS_DIR"/* 2>/dev/null | head -n 1)
+  if [ -n "$latest_session" ] && [ -f "$latest_session/transcript.json" ]; then
+    echo "[+] Last 5 input prompts from $latest_session/transcript.json:"
+    jq -r '.[] | .input // empty' "$latest_session/transcript.json" | tail -n 5
+  fi
+fi


### PR DESCRIPTION
## Summary
- create `verify_codex_changes.sh` to audit repository and recent Codex sessions
- run the script in new `verify-codex.yml` workflow on pushes to `main`

## Testing
- `./scripts/verify_codex_changes.sh | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6840e439b62c83308ac06ca578da2a5f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added an automated workflow to verify recent code changes and review Codex session history on each push to the main branch.
  - Introduced a script to list recently modified files and summarize the latest Codex session activity for improved change tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->