### PR TITLE
Fix CI shell lint issue

### DIFF
--- a/devops/scripts/executable_export-gpg-keys.sh
+++ b/devops/scripts/executable_export-gpg-keys.sh
@@ -16,7 +16,7 @@ apt-key list | grep -E '^pub' | while read -r line; do
   KEY_ID=$(echo "$line" | awk '{print $2}' | cut -d'/' -f2)
   if [[ -n "$KEY_ID" ]]; then
     echo "🔑 Exporting $KEY_ID..."
-    apt-key export "$KEY_ID" > "~/gpg-export/$KEY_ID.gpg"
+    apt-key export "$KEY_ID" > "$HOME/gpg-export/$KEY_ID.gpg"
   fi
 done
 


### PR DESCRIPTION
## Summary
- fix shellcheck warning by using $HOME in export script

## Testing
- `ruff check python/`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840a9175a1883309ef900812b9b9237