### PR TITLE
Add Jenkins bootstrap for GPT chat state

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,15 @@
+pipeline {
+    agent any
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Sync GPT State') {
+            steps {
+                sh './devops/sync/executable_sync-gpt.sh'
+            }
+        }
+    }
+}

--- a/docs/chat-bootstrap-jenkins.md
+++ b/docs/chat-bootstrap-jenkins.md
@@ -1,0 +1,57 @@
+# Jenkins Bootstrap for GPT Chats
+
+This guide explains how to persist GPT conversation context using **gptstate** and Jenkins so new sessions can resume from where previous chats ended.
+
+## 1. Initialize `gptstate`
+
+Run the provided script to set up a persistent log directory and push it to your dotfiles repository managed by `chezmoi`:
+
+```bash
+./devops/scripts/executable_init-gptstate-sync.sh
+```
+
+The script creates `~/.gptstate` with a markdown log (`state.md`) and a JSONL log (`logs/state.jsonl`). Both files are tracked and synced through GitHub.
+
+## 2. Jenkins Pipeline
+
+Create a Jenkinsfile in the repository to automate syncing after each chat or on a schedule:
+
+```groovy
+pipeline {
+    agent any
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+        stage('Sync GPT State') {
+            steps {
+                sh './devops/sync/executable_sync-gpt.sh'
+            }
+        }
+    }
+}
+```
+
+This pipeline checks out the repo and runs the `sync-gpt.sh` script, which commits any new log entries and pushes them to GitHub.
+
+## 3. Starting New Chats
+
+Before beginning a new chat session, pull the latest conversation state:
+
+```bash
+chezmoi update --apply
+```
+
+or run the sync script directly:
+
+```bash
+./devops/sync/executable_sync-gpt.sh
+```
+
+Then inspect `~/.gptstate/state.md` or `logs/state.jsonl` to recall the previous context.
+
+---
+
+Using Jenkins to automatically push updates ensures each chat session has access to the most recent GPT logs, providing seamless continuity across conversations.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,3 +9,4 @@ Welcome to **Wingman** – your DevOps automation hub.
 - [CI/CD Status](https://github.com/1tsjeremiah/wingman/actions)
 - [Docs](./index.md)
 - [Remote Dotfile Sync](./chezmoi-server-setup.md)
+- [Jenkins Chat Bootstrap](./chat-bootstrap-jenkins.md)


### PR DESCRIPTION
## Summary
- add docs on using Jenkins and gptstate for persistent chat continuity
- provide sample Jenkinsfile
- link bootstrap doc from the docs index

## Testing
- `ruff check python` *(fails: SyntaxError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `npm test --silent` in `node/` *(prints 'No tests yet')*
- `docker build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d81959208330bca5d3f770dca7b2